### PR TITLE
output execution time for importers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "spryker/kernel": "^3.0.0",
     "spryker/propel-orm": "^1.0.0",
     "spryker/symfony": "^3.0.0",
-    "spryker/touch": "^3.0.0"
+    "spryker/touch": "^3.0.0",
+    "symfony/stopwatch": "^2.8|^3.0.0"
   },
   "require-dev": {
     "spryker/code-sniffer": "*",

--- a/src/Spryker/Shared/DataImport/Transfer/data-import.transfer.xml
+++ b/src/Spryker/Shared/DataImport/Transfer/data-import.transfer.xml
@@ -23,6 +23,7 @@
 
     <transfer name="DataImporterReport">
         <property name="importType" type="string" />
+        <property name="importTime" type="int" />
         <property name="importedDataSetCount" type="int" />
         <property name="expectedImportableDataSetCount" type="int" />
         <property name="isReaderCountable" type="bool" />

--- a/src/Spryker/Zed/DataImport/Business/Model/DataImporter.php
+++ b/src/Spryker/Zed/DataImport/Business/Model/DataImporter.php
@@ -18,6 +18,7 @@ use Spryker\Zed\DataImport\Business\Model\DataReader\DataReaderInterface;
 use Spryker\Zed\DataImport\Business\Model\DataSet\DataSetInterface;
 use Spryker\Zed\DataImport\Business\Model\DataSet\DataSetStepBrokerAwareInterface;
 use Spryker\Zed\DataImport\Business\Model\DataSet\DataSetStepBrokerInterface;
+use Symfony\Component\Stopwatch\Stopwatch;
 
 class DataImporter implements
     DataImporterBeforeImportAwareInterface,
@@ -50,6 +51,8 @@ class DataImporter implements
      * @var \Spryker\Zed\DataImport\Business\Model\DataSet\DataSetStepBrokerInterface[]
      */
     protected $dataSetStepBroker = [];
+
+    const STOPWATCH_EVENT_NAME = 'import';
 
     /**
      * @param string $importType
@@ -123,6 +126,9 @@ class DataImporter implements
 
         $this->beforeImport();
 
+        $stopWatch = new Stopwatch();
+        $stopWatch->start(self::STOPWATCH_EVENT_NAME);
+
         foreach ($dataReader as $dataSet) {
             try {
                 $this->importDataSet($dataSet);
@@ -138,6 +144,10 @@ class DataImporter implements
 
             unset($dataSet);
         }
+
+        $event = $stopWatch->stop(self::STOPWATCH_EVENT_NAME);
+
+        $dataImporterReportTransfer->setImportTime($event->getDuration());
 
         $this->afterImport();
 

--- a/src/Spryker/Zed/DataImport/Communication/Console/DataImportConsole.php
+++ b/src/Spryker/Zed/DataImport/Communication/Console/DataImportConsole.php
@@ -156,6 +156,7 @@ class DataImportConsole extends Console
             . 'Importer type: <fg=green>%s</>' . PHP_EOL
             . 'Importable DataSets: <fg=green>%s</>' . PHP_EOL
             . 'Imported DataSets: <fg=green>%s</>' . PHP_EOL
+            . 'Import Time Used (in ms): <fg=green>%s</>' . PHP_EOL
             . 'Import status: %s</>';
 
         $this->info(sprintf(
@@ -163,6 +164,7 @@ class DataImportConsole extends Console
             $dataImporterReport->getImportType(),
             $dataImporterReport->getExpectedImportableDataSetCount(),
             $dataImporterReport->getImportedDataSetCount(),
+            $dataImporterReport->getImportTime(),
             $this->getImportStatus($dataImporterReport)
         ));
     }


### PR DESCRIPTION
```
vagrant@spryker-vagrant ➜  current git:(master) ✗  ./vendor/bin/console data:import:product-price
Store: DE | Environment: development
Start "product-price" import

Importer type: product-price
Importable DataSets: 29688
Imported DataSets: 29688
Import Time Used: 271.17686891556
Import status: Successful
```

collector exports should probably also get something like this for each collector something like:
```
vagrant@spryker-vagrant ➜  current git:(master) ✗  ./vendor/bin/console collector:storage:export

[..]

Locale: en_US
-------------
 * product_abstract (345 in 1.17686891556 seconds)
```