### PR TITLE
Catching all throwable exceptions

### DIFF
--- a/src/Spryker/Zed/DataImport/Business/Model/DataReader/CsvReader/CsvReader.php
+++ b/src/Spryker/Zed/DataImport/Business/Model/DataReader/CsvReader/CsvReader.php
@@ -173,7 +173,7 @@ class CsvReader implements DataReaderInterface, ConfigurableDataReaderInterface,
             try {
                 /** @var array $dataSet */
                 $dataSet = array_combine($this->dataSetKeys, $dataSet);
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
                 throw new DataSetWithHeaderCombineFailedException(sprintf(
                     'Can not combine data set header with current data set. Keys: "%s", Values "%s"',
                     implode(', ', $this->dataSetKeys),

--- a/src/Spryker/Zed/DataImport/Business/Model/DataReader/CsvReader/CsvReader.php
+++ b/src/Spryker/Zed/DataImport/Business/Model/DataReader/CsvReader/CsvReader.php
@@ -8,7 +8,6 @@
 namespace Spryker\Zed\DataImport\Business\Model\DataReader\CsvReader;
 
 use Countable;
-use Exception;
 use Generated\Shared\Transfer\DataImporterReaderConfigurationTransfer;
 use SplFileObject;
 use Spryker\Zed\DataImport\Business\Exception\DataReaderException;
@@ -16,6 +15,7 @@ use Spryker\Zed\DataImport\Business\Exception\DataSetWithHeaderCombineFailedExce
 use Spryker\Zed\DataImport\Business\Model\DataReader\ConfigurableDataReaderInterface;
 use Spryker\Zed\DataImport\Business\Model\DataReader\DataReaderInterface;
 use Spryker\Zed\DataImport\Business\Model\DataSet\DataSetInterface;
+use Throwable;
 
 class CsvReader implements DataReaderInterface, ConfigurableDataReaderInterface, Countable
 {
@@ -173,7 +173,7 @@ class CsvReader implements DataReaderInterface, ConfigurableDataReaderInterface,
             try {
                 /** @var array $dataSet */
                 $dataSet = array_combine($this->dataSetKeys, $dataSet);
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 throw new DataSetWithHeaderCombineFailedException(sprintf(
                     'Can not combine data set header with current data set. Keys: "%s", Values "%s"',
                     implode(', ', $this->dataSetKeys),


### PR DESCRIPTION
## PR Description

If

`$dataSet = array_combine($this->dataSetKeys, $dataSet);`

throws an exception the catch block will not catch it if just \exception is caught.

In my case I had faulty CSV and it took ages to find the cause. And later I couldn't add a break point without chaning the core code. Maybe in old PHP Versions this did once work. But we use PHP 8.1 now and as far as I read the PHP manual this is PHP 5 legacy.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
